### PR TITLE
Updated Python requirement and removed links to Python 3.4 installers

### DIFF
--- a/wiki/PyYAML.html
+++ b/wiki/PyYAML.html
@@ -338,7 +338,7 @@ max-width: 44em; }
 <li>relatively sensible error messages.</li>
 </ul>
 <h2 id="requirements">Requirements</h2>
-<p>PyYAML requires Python 2.7 or Python 3.4+.</p>
+<p>PyYAML requires Python 2.7 or Python 3.5+.</p>
 <h2 id="download-and-installation">Download and Installation</h2>
 <p>The current stable release of PyYAML: <em>5.3</em>.</p>
 <p>Download links:</p>
@@ -347,7 +347,6 @@ max-width: 44em; }
 <li><em>Windows installers (32-bit)</em>:
 <ul>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp27-cp27m-win32.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp27-cp27m-win32.whl</a> (for Python 2.7)</li>
-<li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp34-cp34m-win32.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp34-cp34m-win32.whl</a> (for Python 3.4)</li>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp35-cp35m-win32.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp35-cp35m-win32.whl</a> (for Python 3.5)</li>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp36-cp36m-win32.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp36-cp36m-win32.whl</a> (for Python 3.6)</li>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win32.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win32.whl</a> (for Python 3.7)</li>
@@ -355,7 +354,6 @@ max-width: 44em; }
 <li><em>Windows installers (64-bit)</em>:
 <ul>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp27-cp27m-win_amd64.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp27-cp27m-win_amd64.whl</a> (for Python 2.7)</li>
-<li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp34-cp34m-win_amd64.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp34-cp34m-win_amd64.whl</a> (for Python 3.4)</li>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp35-cp35m-win_amd64.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp35-cp35m-win_amd64.whl</a> (for Python 3.5)</li>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp36-cp36m-win_amd64.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp36-cp36m-win_amd64.whl</a> (for Python 3.6)</li>
 <li><a href="http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win_amd64.whl" class="uri">http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win_amd64.whl</a> (for Python 3.7)</li>

--- a/wiki/PyYAML.md
+++ b/wiki/PyYAML.md
@@ -25,7 +25,7 @@ PyYAML features
 
 ## Requirements
 
-PyYAML requires Python 2.7 or Python 3.4+.
+PyYAML requires Python 2.7 or Python 3.5+.
 
 ## Download and Installation
 
@@ -37,13 +37,11 @@ Download links:
 <!-- * *ZIP package*: <http://pyyaml.org/download/pyyaml/PyYAML-5.3.zip> -->
 * *Windows installers (32-bit)*:
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp27-cp27m-win32.whl> (for Python 2.7)
-    * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp34-cp34m-win32.whl> (for Python 3.4)
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp35-cp35m-win32.whl> (for Python 3.5)
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp36-cp36m-win32.whl> (for Python 3.6)
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win32.whl> (for Python 3.7)
 * *Windows installers (64-bit)*:
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp27-cp27m-win_amd64.whl> (for Python 2.7)
-    * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp34-cp34m-win_amd64.whl> (for Python 3.4)
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp35-cp35m-win_amd64.whl> (for Python 3.5)
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp36-cp36m-win_amd64.whl> (for Python 3.6)
     * <http://pyyaml.org/download/pyyaml/PyYAML-5.3-cp37-cp37m-win_amd64.whl> (for Python 3.7)


### PR DESCRIPTION
An issue in the PyYAML 5.3 release removed support for Python 3.4: https://github.com/yaml/pyyaml/pull/345