### PR TITLE
Just a few small CSS improvements for pyyaml documentation

### DIFF
--- a/bin/update-index-html.pl
+++ b/bin/update-index-html.pl
@@ -28,7 +28,11 @@ sub update {
 
     my $html = <<"EOM";
 <html>
-<head><title>Index of /$dir/</title></head>
+<head><title>Index of /$dir/</title>
+<style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+</style>
+</head>
 <body bgcolor="white">
 <h1>Index of /$dir/</h1><hr>
 <table>

--- a/download/index.html
+++ b/download/index.html
@@ -1,5 +1,9 @@
 <html>
-<head><title>Index of /download/</title></head>
+<head><title>Index of /download/</title>
+<style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+</style>
+</head>
 <body bgcolor="white">
 <h1>Index of /download/</h1><hr>
 <table>

--- a/download/libyaml/index.html
+++ b/download/libyaml/index.html
@@ -1,5 +1,9 @@
 <html>
-<head><title>Index of /download/libyaml/</title></head>
+<head><title>Index of /download/libyaml/</title>
+<style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+</style>
+</head>
 <body bgcolor="white">
 <h1>Index of /download/libyaml/</h1><hr>
 <table>

--- a/download/pysyck/index.html
+++ b/download/pysyck/index.html
@@ -1,5 +1,9 @@
 <html>
-<head><title>Index of /download/pysyck/</title></head>
+<head><title>Index of /download/pysyck/</title>
+<style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+</style>
+</head>
 <body bgcolor="white">
 <h1>Index of /download/pysyck/</h1><hr>
 <table>

--- a/download/pyyaml-legacy/index.html
+++ b/download/pyyaml-legacy/index.html
@@ -1,5 +1,9 @@
 <html>
-<head><title>Index of /download/pyyaml-legacy/</title></head>
+<head><title>Index of /download/pyyaml-legacy/</title>
+<style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+</style>
+</head>
 <body bgcolor="white">
 <h1>Index of /download/pyyaml-legacy/</h1><hr>
 <table>

--- a/download/pyyaml/index.html
+++ b/download/pyyaml/index.html
@@ -1,5 +1,9 @@
 <html>
-<head><title>Index of /download/pyyaml/</title></head>
+<head><title>Index of /download/pyyaml/</title>
+<style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+</style>
+</head>
 <body bgcolor="white">
 <h1>Index of /download/pyyaml/</h1><hr>
 <table>

--- a/wiki/PyYAML.html
+++ b/wiki/PyYAML.html
@@ -12,6 +12,8 @@
       div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
   <style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+pre { background-color: #EEE; padding: 5px 15px 5px 15px }
 a.sourceLine { display: inline-block; line-height: 1.25; }
 a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
 a.sourceLine:empty { height: 1.2em; }

--- a/wiki/PyYAMLDocumentation.html
+++ b/wiki/PyYAMLDocumentation.html
@@ -12,6 +12,8 @@
       div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
   <style type="text/css">
+body { font-family: sans; line-height: 1.5; color: #111 }
+pre { background-color: #EEE; padding: 5px 15px 5px 15px }
 a.sourceLine { display: inline-block; line-height: 1.25; }
 a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
 a.sourceLine:empty { height: 1.2em; }

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -23,6 +23,9 @@ line-height: 1.15;
 
 body {
 margin: 0;
+font-family: sans;
+line-height: 1.5;
+color: #111;
 }
 
 article,


### PR DESCRIPTION
Hello,

This is just a few CSS improvements to increase readability. 

Obligatory before/after:

Before:
![2024-04-12_08-33_1](https://github.com/yaml/pyyaml.org/assets/41827/4bf1bb42-d4b4-454e-a54d-9d827d82d88a)

After:
![2024-04-12_08-33](https://github.com/yaml/pyyaml.org/assets/41827/2ba2a10a-6c30-4486-9383-f94c72f1dc1e)

Kind regards,